### PR TITLE
Add AWS Lambda wrapper

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,10 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/go:1-1.21-bullseye",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/customink/codespaces-features/sam-cli:1": {},
+		"ghcr.io/devcontainers/features/aws-cli:1": {},
+		"ghcr.io/devcontainers-contrib/features/aws-cdk:2": {}
 	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .env
-/server
+/out

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,18 @@ default: help
 help: # Show help for each of the Makefile recipes
 	@grep -E '^[a-zA-Z0-9 -]+:.*#' Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
 
-server: $(wildcard cmd/server/**/*.go) $(wildcard internal/**/*.go) # Build the server application
-	go build -o server ./cmd/server
+.PHONY: server
+server: out/server # Build the server application
+
+out/server: $(wildcard cmd/server/**/*.go) $(wildcard internal/**/*.go)
+	go build -o out/server ./cmd/server
+
+.PHONY: lambda
+lambda: out/function.zip # Build the AWS lambda application
+
+out/function.zip: $(wildcard cmd/lambda/**/*.go) $(wildcard internal/**/*.go)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags lambda.norpc -o out/bootstrap ./cmd/lambda && cd out && zip function.zip bootstrap
 
 .PHONY: clean
 clean: # Delete any build artefacts
-	rm -f server
+	rm -rf out

--- a/cmd/lambda/lambda.go
+++ b/cmd/lambda/lambda.go
@@ -19,7 +19,9 @@ type handlerResponse struct {
 }
 
 func handler(ctx context.Context) (handlerResponse, error) {
-	headers := http.Header{}
+	headers := http.Header{
+		"Cache-Control": {"max-age=0"},
+	}
 	resp, err := wasteworks.FetchCalendarWithContext(ctx)
 	if err != nil {
 		headers.Add("Content-Type", "text/plain")

--- a/cmd/lambda/lambda.go
+++ b/cmd/lambda/lambda.go
@@ -19,7 +19,7 @@ type handlerResponse struct {
 }
 
 func handler(ctx context.Context) (handlerResponse, error) {
-	var headers http.Header
+	headers := http.Header{}
 	resp, err := wasteworks.FetchCalendarWithContext(ctx)
 	if err != nil {
 		headers.Add("Content-Type", "text/plain")

--- a/cmd/lambda/lambda.go
+++ b/cmd/lambda/lambda.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"unicode/utf8"
+
+	"bitsden.com/wasteworks/internal/wasteworks"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type handlerResponse struct {
+	StatusCode int `json:"statusCode"`
+	Headers http.Header
+	Body string `json:"body"`
+	IsBase64Encoded bool `json:"isBase64Encoded,omitempty"`
+}
+
+func handler(ctx context.Context) (handlerResponse, error) {
+	var headers http.Header
+	resp, err := wasteworks.FetchCalendarWithContext(ctx)
+	if err != nil {
+		headers.Add("Content-Type", "text/plain")
+		
+		return handlerResponse{
+			StatusCode: http.StatusInternalServerError,
+			Headers: headers,
+			Body: http.StatusText(http.StatusInternalServerError),
+		}, nil
+	}
+	defer resp.Body.Close()
+
+	var output string
+	isBase64 := false
+	bb, err := io.ReadAll(resp.Body)
+	if err != nil {
+		headers.Add("Content-Type", "text/plain")
+
+		return handlerResponse{
+			StatusCode: http.StatusInternalServerError,
+			Headers: headers,
+			Body: http.StatusText(http.StatusInternalServerError),
+		}, nil
+	}
+
+	if utf8.Valid(bb) {
+		output = string(bb)
+	} else {
+		output = base64.StdEncoding.EncodeToString(bb)
+		isBase64 = true
+	}
+
+	// Copy headers from the calendar response to the actual request response
+	for name, values := range resp.Header {
+		for _, value := range values {
+			headers.Add(name, value)
+		}
+	}
+
+	hr := handlerResponse{
+		StatusCode: http.StatusOK,
+		Headers: headers,
+		Body: output,
+		IsBase64Encoded: isBase64,
+	}
+
+	return hr, nil
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,17 @@
 module bitsden.com/wasteworks
 
 go 1.21.0
+
+require (
+	github.com/aws/aws-cdk-go/awscdk/v2 v2.115.0
+	github.com/aws/aws-lambda-go v1.43.0
+)
+
+require (
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
+	github.com/aws/constructs-go/constructs/v10 v10.3.0 // indirect
+	github.com/aws/jsii-runtime-go v1.93.0 // indirect
+	github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.201 // indirect
+	github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2 v2.1.2 // indirect
+	github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv6/v2 v2.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/aws/aws-cdk-go/awscdk/v2 v2.115.0 h1:KFK218X4pRdoInvQrHyLjtdYd8Klos67ycDFfUTUPl8=
+github.com/aws/aws-cdk-go/awscdk/v2 v2.115.0/go.mod h1:0/6yeUWiya0tE/SKKJ++VkhP/M9QxTBjIb2ZHnLZOH8=
+github.com/aws/aws-lambda-go v1.43.0 h1:Tdu7SnMB5bD+CbdnSq1Dg4sM68vEuGIDcQFZ+IjUfx0=
+github.com/aws/aws-lambda-go v1.43.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/aws/constructs-go/constructs/v10 v10.3.0 h1:LsjBIMiaDX/vqrXWhzTquBJ9pPdi02/H+z1DCwg0PEM=
+github.com/aws/constructs-go/constructs/v10 v10.3.0/go.mod h1:GgzwIwoRJ2UYsr3SU+JhAl+gq5j39bEMYf8ev3J+s9s=
+github.com/aws/jsii-runtime-go v1.93.0 h1:QIFUKmsU0NpYZPhP24WSFn74PWlUKgJV6eQIe5/BfBU=
+github.com/aws/jsii-runtime-go v1.93.0/go.mod h1:D7yFSwtXpTMqVB3c5IHQ1Z42p+pgkTkU7FqKBll33Sk=
+github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.201 h1:0za9Qxne1jWawrxUnoli/zDVgBptS5nZpFrdLmxP5wA=
+github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.201/go.mod h1:SrEoz1cauDlwKmCqgcE6JsfbW54xuz0R5O5IADdjUHo=
+github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2 v2.1.2 h1:k+WD+6cERd59Mao84v0QtRrcdZuuSMfzlEmuIypKnVs=
+github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2 v2.1.2/go.mod h1:CvFHBo0qcg8LUkJqIxQtP1rD/sNGv9bX3L2vHT2FUAo=
+github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv6/v2 v2.0.1 h1:MBBQNKKPJ5GArbctgwpiCy7KmwGjHDjUUH5wEzwIq8w=
+github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv6/v2 v2.0.1/go.mod h1:/2WiXEft9s8ViJjD01CJqDuyJ8HXBjhBLtK5OvJfdSc=

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,0 +1,9 @@
+version = 0.1
+[default.deploy.parameters]
+stack_name = "wasteworks-app"
+resolve_s3 = true
+s3_prefix = "wasteworks-app"
+region = "eu-west-2"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+image_repositories = []

--- a/template.yml
+++ b/template.yml
@@ -9,6 +9,7 @@ Resources:
       CodeUri: ./out/function.zip
       Handler: bootstrap
       Runtime: provided.al2023
+      Timeout: 10
       Architectures:
         - x86_64
       FunctionUrlConfig:

--- a/template.yml
+++ b/template.yml
@@ -2,6 +2,13 @@ AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
 
 Resources:
+  AppRegistryApplicationStackAssociation:
+    Type: AWS::ServiceCatalogAppRegistry::ResourceAssociation
+    Properties:
+      Application: arn:aws:servicecatalog:eu-west-2:770389572600:/applications/0av8nux3086tr5ldsv33wzme45
+      Resource:
+        Ref: AWS::StackId
+      ResourceType: CFN_STACK
   WasteworksApplication:
     Type: AWS::Serverless::Function
     Properties:
@@ -16,6 +23,8 @@ Resources:
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: BUFFERED
+      Tags:
+        awsApplication: arn:aws:resource-groups:eu-west-2:770389572600:group/Wasteworks/0av8nux3086tr5ldsv33wzme45
   WasteworksApplicationLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -25,8 +34,77 @@ Resources:
           - - "/aws/lambda/"
             - Ref: WasteworksApplication
       RetentionInDays: 30
-
+  WasteworksDistribution:
+    Type: AWS::CloudFront::Distribution
+    DependsOn:
+      - WasteworksApplication
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Aliases:
+          - wasteworks.bitsden.app
+        Origins:
+          - Id: WasteworksApplication
+            DomainName:
+              Fn::Select:
+                - 2
+                - Fn::Split:
+                    - "/"
+                    - Fn::GetAtt: WasteworksApplicationUrl.FunctionUrl
+            CustomOriginConfig:
+              HTTPSPort: 443
+              OriginProtocolPolicy: https-only
+        ViewerCertificate:
+          AcmCertificateArn: arn:aws:acm:us-east-1:770389572600:certificate/609edb1a-6d36-41a4-bc33-fae34567b1c0
+          MinimumProtocolVersion: TLSv1.2_2021
+          SslSupportMethod: sni-only
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+          CachePolicyId:
+            Ref: WasteworksApplicationCachePolicy
+          OriginRequestPolicyId:
+            Ref: WasteworksApplicationRequestPolicy
+          TargetOriginId: WasteworksApplication
+          ViewerProtocolPolicy: https-only
+  WasteworksApplicationCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        Name: WasteworksApplication
+        DefaultTTL: 0
+        MaxTTL: 0
+        MinTTL: 0
+        ParametersInCacheKeyAndForwardedToOrigin:
+          EnableAcceptEncodingBrotli: false
+          EnableAcceptEncodingGzip: false
+          CookiesConfig:
+            CookieBehavior: none
+          HeadersConfig:
+            HeaderBehavior: none
+          QueryStringsConfig:
+            QueryStringBehavior: none
+  WasteworksApplicationRequestPolicy:
+    Type: AWS::CloudFront::OriginRequestPolicy
+    Properties:
+      OriginRequestPolicyConfig:
+        Name: WasteworksApplication
+        CookiesConfig:
+          CookieBehavior: all
+        HeadersConfig:
+          HeaderBehavior: allExcept
+          Headers:
+            - Host
+        QueryStringsConfig:
+          QueryStringBehavior: all
+          
 Outputs:
+  WasteworksApplicationDistributionEndpoint:
+    Description: Wasteworks application cloudfront URL endpoint
+    Value:
+      Fn::GetAtt: WasteworksDistribution.DomainName
   WasteworksApplicationUrlEndpoint:
     Description: Wasteworks application function URL endpoint
     Value:

--- a/template.yml
+++ b/template.yml
@@ -10,6 +10,7 @@ Resources:
       Handler: bootstrap
       Runtime: provided.al2023
       Timeout: 10
+      ReservedConcurrentExecutions: 1
       Architectures:
         - x86_64
       FunctionUrlConfig:

--- a/template.yml
+++ b/template.yml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  WasteworksApplication:
+    Type: AWS::Serverless::Function
+    Properties:
+      PackageType: Zip
+      CodeUri: ./out/function.zip
+      Handler: bootstrap
+      Runtime: provided.al2023
+      Architectures:
+        - x86_64
+      FunctionUrlConfig:
+        AuthType: NONE
+        InvokeMode: BUFFERED
+  WasteworksApplicationLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - - "/aws/lambda/"
+            - Ref: WasteworksApplication
+      RetentionInDays: 30
+
+Outputs:
+  WasteworksApplicationUrlEndpoint:
+    Description: Wasteworks application function URL endpoint
+    Value:
+      Fn::GetAtt: WasteworksApplicationUrl.FunctionUrl


### PR DESCRIPTION
Merging this will add a wrapper of the calendar proxy function based around AWS Lambda. This should offer a largely free execution environment.

CloudFront is being used as an SSL terminator in front of the Lambda function URL for a custom domain.